### PR TITLE
Ensure Var/Lit methods can be inlined

### DIFF
--- a/varisat-formula/src/lit.rs
+++ b/varisat-formula/src/lit.rs
@@ -22,6 +22,7 @@ impl Var {
     /// Creates a variable from a 1-based index as used in the DIMCAS CNF encoding.
     ///
     /// The parameter must be positive and may not represent a variable past `Var::max_var()`.
+    #[inline]
     pub fn from_dimacs(number: isize) -> Var {
         debug_assert!(number > 0);
         Var::from_index((number - 1) as usize)
@@ -30,6 +31,7 @@ impl Var {
     /// Creates a variable from a 0-based index.
     ///
     /// The index may not represent a variable past `Var::max_var()`.
+    #[inline]
     pub fn from_index(index: usize) -> Var {
         debug_assert!(index <= Var::max_var().index());
         Var {
@@ -38,11 +40,13 @@ impl Var {
     }
 
     /// The 1-based index representing this variable in the DIMACS CNF encoding.
+    #[inline]
     pub fn to_dimacs(self) -> isize {
         (self.index + 1) as isize
     }
 
     /// The 0-based index representing this variable.
+    #[inline]
     pub const fn index(self) -> usize {
         self.index as usize
     }
@@ -68,6 +72,7 @@ impl Var {
     /// Creates a literal from this var and a `bool` that is `true` when the literal is positive.
     ///
     /// Shortcut for `Lit::from_var(var, polarity)`.
+    #[inline]
     pub fn lit(self, polarity: bool) -> Lit {
         Lit::from_var(self, polarity)
     }
@@ -75,6 +80,7 @@ impl Var {
     /// Creates a positive literal from this var.
     ///
     /// Shortcut for `Lit::positive(var)`.
+    #[inline]
     pub fn positive(self) -> Lit {
         Lit::positive(self)
     }
@@ -82,6 +88,7 @@ impl Var {
     /// Creates a negative literal from this var.
     ///
     /// Shortcut for `Lit::negative(var)`.
+    #[inline]
     pub fn negative(self) -> Lit {
         Lit::negative(self)
     }
@@ -121,27 +128,32 @@ pub struct Lit {
 
 impl Lit {
     /// Creates a literal from a `Var` and a `bool` that is `true` when the literal is positive.
+    #[inline]
     pub fn from_var(var: Var, polarity: bool) -> Lit {
         Lit::from_litidx(var.index, polarity)
     }
 
     /// Create a positive literal from a `Var`.
+    #[inline]
     pub fn positive(var: Var) -> Lit {
         Lit::from_var(var, true)
     }
 
     /// Create a negative literal from a `Var`.
+    #[inline]
     pub fn negative(var: Var) -> Lit {
         Lit::from_var(var, false)
     }
 
     /// Create a literal from a variable index and a `bool` that is `true` when the literal is
     /// positive.
+    #[inline]
     pub fn from_index(index: usize, polarity: bool) -> Lit {
         Lit::from_var(Var::from_index(index), polarity)
     }
 
     /// Create a literal with the given encoding.
+    #[inline]
     pub fn from_code(code: usize) -> Lit {
         debug_assert!(code <= Var::max_var().index() * 2 + 1);
         Lit {
@@ -149,6 +161,7 @@ impl Lit {
         }
     }
 
+    #[inline]
     fn from_litidx(index: LitIdx, polarity: bool) -> Lit {
         debug_assert!(index <= Var::max_var().index);
         Lit {
@@ -160,11 +173,13 @@ impl Lit {
     ///
     /// The absolute value is used as 1-based index, the sign of
     /// the integer is used as sign of the literal.
+    #[inline]
     pub fn from_dimacs(number: isize) -> Lit {
         Lit::from_var(Var::from_dimacs(number.abs()), number > 0)
     }
 
     /// 1-based Integer representation of the literal, opposite of `from_dimacs`.
+    #[inline]
     pub fn to_dimacs(self) -> isize {
         let mut number = self.var().to_dimacs();
         if self.is_negative() {
@@ -174,11 +189,13 @@ impl Lit {
     }
 
     /// 0-based index of the literal's _variable_.
+    #[inline]
     pub fn index(self) -> usize {
         (self.code >> 1) as usize
     }
 
     /// The literal's variable.
+    #[inline]
     pub fn var(self) -> Var {
         Var {
             index: self.code >> 1,
@@ -186,11 +203,13 @@ impl Lit {
     }
 
     /// Whether the literal is negative, i.e. a negated variable.
+    #[inline]
     pub fn is_negative(self) -> bool {
         (self.code & 1) != 0
     }
 
     /// Whether the literal is positive, i.e. a non-negated variable.
+    #[inline]
     pub fn is_positive(self) -> bool {
         !self.is_negative()
     }
@@ -198,6 +217,7 @@ impl Lit {
     /// Two times the variable's index for positive literals and one more for negative literals.
     ///
     /// This is also the internal encoding.
+    #[inline]
     pub fn code(self) -> usize {
         self.code as usize
     }
@@ -205,6 +225,8 @@ impl Lit {
 
 impl ops::Not for Lit {
     type Output = Lit;
+
+    #[inline]
     fn not(self) -> Lit {
         Lit {
             code: self.code ^ 1,
@@ -215,6 +237,7 @@ impl ops::Not for Lit {
 impl ops::BitXor<bool> for Lit {
     type Output = Lit;
 
+    #[inline]
     fn bitxor(self, rhs: bool) -> Lit {
         Lit {
             code: self.code ^ (rhs as LitIdx),
@@ -223,6 +246,7 @@ impl ops::BitXor<bool> for Lit {
 }
 
 impl From<Var> for Lit {
+    #[inline]
     fn from(var: Var) -> Lit {
         Lit::positive(var)
     }


### PR DESCRIPTION
Extracting the varisat-formula crate caused a rather larger performance
regression, as it prevented some essential inlining to happen.