### PR TITLE
Emit propagated unit clauses for DRAT proofs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - run: |
           export VARISAT_HAVE_DRAT_TRIM=1
           export VARISAT_HAVE_CHECK_LRAT=1
+          export VARISAT_HAVE_RATE=1
           cargo build --verbose --all --all-targets
           python3 .circleci/save_binaries.py
       - persist_to_workspace:

--- a/varisat/build.rs
+++ b/varisat/build.rs
@@ -20,11 +20,30 @@ fn have_drat_trim() -> Result<(), Error> {
     Ok(())
 }
 
+fn have_rate() -> Result<(), Error> {
+    println!("rerun-if-env-changed=VARISAT_HAVE_RATE");
+    if env::var("VARISAT_HAVE_RATE").is_ok() {
+        return Ok(());
+    }
+
+    let _ = Command::new("rate").arg("--version").output()?;
+
+    Ok(())
+}
+
 fn main() {
     match have_drat_trim() {
         Ok(_) => println!("cargo:rustc-cfg=test_drat_trim"),
         Err(err) => println!(
-            "cargo:warning=drat-trim utility not found, some tests will be disabled: {}",
+            "cargo:warning=drat-trim proof checker not found, some tests will be disabled: {}",
+            err
+        ),
+    }
+
+    match have_rate() {
+        Ok(_) => println!("cargo:rustc-cfg=test_rate"),
+        Err(err) => println!(
+            "cargo:warning=rate proof checker not found, some tests will be disabled: {}",
             err
         ),
     }

--- a/varisat/src/proof.rs
+++ b/varisat/src/proof.rs
@@ -120,11 +120,6 @@ impl<'a> Proof<'a> {
         self.native_format()
     }
 
-    /// Whether unit clauses discovered through unit propagation have to be proven.
-    pub fn prove_propagated_unit_clauses(&self) -> bool {
-        self.native_format()
-    }
-
     /// Whether found models are included in the proof.
     pub fn models_in_proof(&self) -> bool {
         self.native_format()

--- a/varisat/src/simplify.rs
+++ b/varisat/src/simplify.rs
@@ -38,16 +38,13 @@ pub fn prove_units<'a>(
 
         for &lit in trail.trail() {
             new_unit = true;
-            let (proof, mut ctx) = ctx.split_part_mut(ProofP);
-            if proof.prove_propagated_unit_clauses() {
-                let ctx_lits = ctx.borrow();
-                let reason = impl_graph.reason(lit.var());
-                if !reason.is_unit() {
-                    let lits = impl_graph.reason(lit.var()).lits(&ctx_lits);
-                    let hash = clause_hash(lits) ^ lit_hash(lit);
+            let ctx_lits = ctx.borrow();
+            let reason = impl_graph.reason(lit.var());
+            if !reason.is_unit() {
+                let lits = impl_graph.reason(lit.var()).lits(&ctx_lits);
+                let hash = clause_hash(lits) ^ lit_hash(lit);
 
-                    unit_proofs.push((lit, hash));
-                }
+                unit_proofs.push((lit, hash));
             }
 
             impl_graph.update_removed_unit(lit.var());


### PR DESCRIPTION
This makes the generated DRAT proofs valid when checking with deletion of
pseudo unit clauses (eg. using rate).

Fixes #64