### PR TITLE
Replace trival uses of match with matches! macro

### DIFF
--- a/varisat/src/proof.rs
+++ b/varisat/src/proof.rs
@@ -110,11 +110,7 @@ impl<'a> Proof<'a> {
 
     /// Are we emitting or checking our native format.
     pub fn native_format(&self) -> bool {
-        self.checker.is_some()
-            || match self.format {
-                Some(ProofFormat::Varisat) => true,
-                _ => false,
-            }
+        self.checker.is_some() || matches!(self.format, Some(ProofFormat::Varisat))
     }
 
     /// Whether clause hashes are required for steps that support them.

--- a/varisat/src/prop/graph.rs
+++ b/varisat/src/prop/graph.rs
@@ -34,10 +34,7 @@ impl Reason {
 
     /// True if a unit clause or assumption and not a propagation.
     pub fn is_unit(&self) -> bool {
-        match self {
-            Reason::Unit => true,
-            _ => false,
-        }
+        matches!(self, Reason::Unit)
     }
 }
 

--- a/varisat/src/solver.rs
+++ b/varisat/src/solver.rs
@@ -44,10 +44,7 @@ pub enum SolverError {
 impl SolverError {
     /// Whether a Solver instance can be used after producing such an error.
     pub fn is_recoverable(&self) -> bool {
-        match self {
-            SolverError::Interrupted => true,
-            _ => false,
-        }
+        matches!(self, SolverError::Interrupted)
     }
 }
 


### PR DESCRIPTION
This is just some trivial code cleanups found by running the [`clippy`](https://github.com/rust-lang/rust-clippy) lint tool. To repro:

```
rustup component add clippy
cargo clippy
```

which for me resulted in:

```
warning: drat-trim proof checker not found, some tests will be disabled: No such file or directory (os error 2)
warning: rate proof checker not found, some tests will be disabled: No such file or directory (os error 2)
warning: match expression looks like `matches!` macro
  --> varisat/varisat/src/solver.rs:48:9
   |
48 | /         match self {
49 | |             SolverError::Interrupted => true,
50 | |             _ => false,
51 | |         }
   | |_________^ help: try this: `matches!(self, SolverError::Interrupted)`
   |
   = note: `#[warn(clippy::match_like_matches_macro)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

warning: match expression looks like `matches!` macro
   --> varisat/varisat/src/proof.rs:114:16
    |
114 |               || match self.format {
    |  ________________^
115 | |                 Some(ProofFormat::Varisat) => true,
116 | |                 _ => false,
117 | |             }
    | |_____________^ help: try this: `matches!(self.format, Some(ProofFormat::Varisat))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

warning: match expression looks like `matches!` macro
  --> varisat/varisat/src/prop/graph.rs:37:9
   |
37 | /         match self {
38 | |             Reason::Unit => true,
39 | |             _ => false,
40 | |         }
   | |_________^ help: try this: `matches!(self, Reason::Unit)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro

warning: 3 warnings emitted

    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
```

There were only 3 warnings, and they were all trivial uses of the `match` expression resulting in `true/false`, which can be more succinctly written using the [`matches!`](https://doc.rust-lang.org/std/macro.matches.html) macro.