### PR TITLE
CnfFormula derives Clone

### DIFF
--- a/varisat-formula/src/cnf.rs
+++ b/varisat-formula/src/cnf.rs
@@ -6,7 +6,7 @@ use crate::lit::{Lit, Var};
 /// A formula in conjunctive normal form (CNF).
 ///
 /// Equivalent to Vec<Vec<Lit>> but more efficient as it uses a single buffer for all literals.
-#[derive(Default, Eq)]
+#[derive(Clone, Default, Eq)]
 pub struct CnfFormula {
     var_count: usize,
     literals: Vec<Lit>,


### PR DESCRIPTION
It seems like there is no reason why CnfFormula should not be cloneable?

Cheers,